### PR TITLE
Fix deprecation warning

### DIFF
--- a/bin/jsweave
+++ b/bin/jsweave
@@ -34,13 +34,15 @@ def getTeX(file_name):
     return TeX
 
 def tex_escape(text):
-    """
+    r"""
         https://stackoverflow.com/questions/16259923/how-can-i-escape-latex-special-characters-inside-django-templates
         :param text: a plain text message
         :return: the message escaped to appear correctly in LaTeX
 
         TODO: what if any conv.key is preceded by one or more backslashes?
+              for example, our json is {'bigdogs': '27\%'}
     """
+
     conv = {
         '&': r'\&',
         '%': r'\%',
@@ -62,14 +64,10 @@ def tex_escape(text):
     return regex.sub(lambda match: conv[match.group()], text)
 
 
-def json_re(value):
-    cad = r"\\jsonsub(\[([^\]]*?)\])?\{" + re.escape(value) + r"\}"
-    return re.compile(cad)
-
-
 def sub(TeX, JS):
     for x, y in JS.items():
-        p = json_re(x)
+        cad = r"\\jsonsub(\[([^\]]*?)\])?\{" + re.escape(x) + r"\}"
+        p = re.compile(cad)
         TeX = p.sub(tex_escape(str(y)), TeX)
     return TeX
 

--- a/tests/jsweave_test.py
+++ b/tests/jsweave_test.py
@@ -4,21 +4,35 @@ from jsweave import sub, check, update, getTeX, getJson
 
 
 def test_sub():
-    TeX = "\\jsonsub[40]{datacrime}"
+    TeX = r"\jsonsub[40]{datacrime}"
     JS = {'datacrime': '30'}
     subd_str = sub(TeX, JS)
     expected_str = '30'
     assert subd_str == expected_str
 
+def test_sub_plus_text():
+    TeX = r"a value of \jsonsub[40]{datacrime} is too high"
+    JS = {'datacrime': '30'}
+    subd_str = sub(TeX, JS)
+    expected_str = 'a value of 30 is too high'
+    assert subd_str == expected_str
+
+def test_sub_no_default():
+    TeX = "\\jsonsub{datacrime} is too high"
+    JS = {'datacrime': '30'}
+    subd_str = sub(TeX, JS)
+    expected_str = '30 is too high'
+    assert subd_str == expected_str
+
 def test_sub_percent():
-    TeX = r"\\jsonsub[40\%]{datacrime}"
+    TeX = r"\jsonsub[40\%]{datacrime}"
     JS = {'datacrime': '30%'}
     subd_str = sub(TeX, JS)
     expected_str = '30\\%'
     assert subd_str == expected_str
 
 def test_sub_integer():
-    TeX = r"\\jsonsub[40]{datacrime}"
+    TeX = r"\jsonsub[40]{datacrime}"
     JS = {'datacrime': 30}
     subd_str = sub(TeX, JS)
     expected_str = '30'
@@ -32,14 +46,14 @@ def test_sub_integer():
 #     assert subd_str == expected_str
 
 def test_update():
-    TeX = r"\\jsonsub[40\%]{datacrime}"
+    TeX = r"\jsonsub[40\%]{datacrime}"
     JS = {'datacrime': '30%'}
     updated_str = update(TeX, JS)
-    expected_str = r'\\jsonsub[30\\%]{datacrime}'
+    expected_str = r'\jsonsub[30\%]{datacrime}'
     assert updated_str == expected_str
 
 def test_check():
-    TeX = r"\\jsonsub[40\%]{datacrime}"
+    TeX = r"\jsonsub[40\%]{datacrime}"
     JS = {'datacrime':'30%'}
     check_output = check(TeX, JS)
     expected_result = [(1, "40\\%", "30\\%")]
@@ -47,7 +61,7 @@ def test_check():
 
 # if no change, then don't report anything
 def test_check2():
-    TeX = r"\\jsonsub[40\%]{datacrime}"
+    TeX = r"\jsonsub[40\%]{datacrime}"
     JS = {'datacrime':'40%'}
     check_output = check(TeX, JS)
     expected_result = []
@@ -72,6 +86,6 @@ def test_acceptance_check():
     expected_result = [
             (11, "20", "77"),
             (13, "204,337.73", "197,283.11"),
-            (15, r"55\\%", r"1\\%")
+            (15, r"55\%", r"1\%")
         ]
     assert check_result == expected_result


### PR DESCRIPTION
Basically every string with a backslash needs to be raw. Sometimes the DeprecationWarning is thrown (e.g., for '\%' even when buried in a triple-quote) other backslashes pass quietly. This covers all of them. 